### PR TITLE
geckodriver support for Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cucumber": "1.2.2",
     "cucumber-html-reporter": "0.2.8",
     "fs-plus": "2.9.1",
-    "geckodriver": "1.1.2",
+    "geckodriver": "^1.4.0",
     "merge": "1.2.0",
     "phantomjs-prebuilt": "2.1.12",
     "require-dir": "0.3.0",


### PR DESCRIPTION
It's failing the npm installation while trying to download geckodriver @1.1.2 on a linux server. please update to 1.4.0 for linux support