### PR TITLE
Added --utam flag to control the UTAM test file compilation process.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ const merge = require('merge');
 const requireDir = require('require-dir');
 const loadTextFile = require('text-files-loader');
 const { cosmiconfigSync } = require('cosmiconfig');
+const { exec } = require("child_process");
 
 // eslint-disable-next-line global-require
 const klassiCli = new (require('@cucumber/cucumber').Cli)({
@@ -95,6 +96,7 @@ program
   )
   .option('--extraSettings <optional>', 'further piped configs split with pipes', '')
   .option('--wdProtocol', 'the switch to change the browser option from devtools to webdriver')
+  .option('--utam', 'used to launch the compilation process of UTAM test files into scripts.')
   .parse(process.argv);
 
 program.on('--help', () => {
@@ -112,6 +114,15 @@ const settings = {
   updateBaselineImage: options.updateBaselineImage,
   remoteService: options.remoteService,
 };
+
+// Use the --utam config to compile the UTAM test files and generate the .JS files.
+if (options.utam) {
+  exec("yarn run utam -c utam.config.js", (err, stdout, stderr) => {
+    if (err) console.error(err);
+    if (stderr) console.error(stderr);
+    console.log(stdout);
+  });
+}
 
 /**
  * Setting envConfig to be global, used within the world.js when building browser

--- a/package.json
+++ b/package.json
@@ -34,10 +34,8 @@
     "start": "nyc node index.js --disableReport --wdProtocol --tags",
     "test": "node index.js --disableReport --wdProtocol --tags",
     "dev": "node index.js --disableReport --tags",
-    "dev:utam": "yarn utam:compile && yarn dev @utam",
     "ltlocal": "node index.js --disableReport --remoteService lambdatest --extraSettings",
     "ciltdev": "nyc node index.js --disableReport --tags @uattest --remoteService lambdatest --extraSettings",
-    "utam:compile": "yarn run utam -c utam.config.js",
     "pkgcheck": "yarn install --check-files"
   },
   "homepage": "https://github.com/larryg01/klassi-js#readme",

--- a/shared-objects/docs/userAgent.txt
+++ b/shared-objects/docs/userAgent.txt
@@ -1,1 +1,1 @@
-Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.115 Safari/537.36


### PR DESCRIPTION
Hello!,

This is an improvement to the UTAM implementation. As we discussed, it involves adding the --utam flag to the commander options and using the switch to execute the Yarn script. Setting the flag when not necessary does not harm the execution of the remaining scripts and not setting it when running UTAM tests just results in Cucumber not being able to find the files.

Cheers!